### PR TITLE
Ignore modification and validation of null objects. Fix NullPointerExcep...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.lotaris.jee</groupId>
   <artifactId>jee-validation</artifactId>
-  <version>0.5.1</version>
+  <version>0.5.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
 	<name>Java EE Validation</name>

--- a/src/main/java/com/lotaris/jee/validation/preprocessing/BeanValidationPreprocessor.java
+++ b/src/main/java/com/lotaris/jee/validation/preprocessing/BeanValidationPreprocessor.java
@@ -1,6 +1,7 @@
 package com.lotaris.jee.validation.preprocessing;
 
 import com.lotaris.jee.validation.AbstractPatchTransferObject;
+import com.lotaris.jee.validation.ApiErrorResponse;
 import com.lotaris.jee.validation.IConstraintConverter;
 import com.lotaris.jee.validation.IErrorCode;
 import com.lotaris.jee.validation.IErrorLocationType;
@@ -79,6 +80,11 @@ public class BeanValidationPreprocessor implements IPreprocessor {
 			}
 
 			patch = (IPatchObject) object;
+		}
+		
+		// Cannot validate null object
+		if (object == null) {
+			return true;
 		}
 
 		// Validate the object. This may be a wrapped object (see JsonRootWrapper).

--- a/src/main/java/com/lotaris/jee/validation/preprocessing/ModifiersPreprocessor.java
+++ b/src/main/java/com/lotaris/jee/validation/preprocessing/ModifiersPreprocessor.java
@@ -124,6 +124,11 @@ public class ModifiersPreprocessor implements IPreprocessor {
 
 	@Override
 	public boolean process(Object object, IPreprocessingConfig config) {
+		
+		// Nothing to modify
+		if (object == null) {
+			return true;
+		}
 
 		fillCache(object.getClass(), processorsCache);
 


### PR DESCRIPTION
Ignore modifications and validations of null objects.
Fix NullPointerException and IllegalArgumentException if passing a null object to the validation preprocessing chain.

Maybe we should consider throwing an exception (Maybe on ValidationPreprocessor.java...) instead of ignoring null object.
