### PR TITLE
Update Jersey in order to use lib with Jackson 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.0 - November 12, 2015
+
+* Update Jersey in order to use Jackson 2.x serialization
+
 ## v0.5.1 - November 17, 2014
 
 * Release on Maven Central

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.lotaris.jee</groupId>
   <artifactId>jee-validation</artifactId>
-  <version>0.5.2</version>
+  <version>0.6.0</version>
   <packaging>jar</packaging>
 
 	<name>Java EE Validation</name>

--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
 		<dependency>
 			<groupId>org.glassfish.jersey.media</groupId>
 			<artifactId>jersey-media-json-jackson</artifactId>
-			<version>2.0</version>
+			<version>2.21</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/src/main/java/com/lotaris/jee/validation/ApiError.java
+++ b/src/main/java/com/lotaris/jee/validation/ApiError.java
@@ -1,7 +1,7 @@
 package com.lotaris.jee.validation;
 
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Detailed error message concerning a JSON document submitted by an API client.

--- a/src/main/java/com/lotaris/jee/validation/ApiErrorResponse.java
+++ b/src/main/java/com/lotaris/jee/validation/ApiErrorResponse.java
@@ -1,11 +1,11 @@
 package com.lotaris.jee.validation;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import org.codehaus.jackson.annotate.JsonIgnore;
 
 /**
  * An API response indicating that one or multiple errors prevented the request from being


### PR DESCRIPTION
Update jersey version used by the lib.

Jersey 2.0 was still using Jackson 1.x (Like on Glassfish 4.0). Since Jersey 2.9, the lib is using version 2.x of Jackson serializer.

See : https://jersey.java.net/documentation/latest/migration.html

```
 With Jersey 2.9, Jackson has been updated to version 2.3.2.
The feature is still configured via mentioned ObjectMapper class, but the package has changed.

    For jackson 1.x, use org.codehaus.jackson.map.ObjectMapper
    For jackson 2.x, use com.fasterxml.jackson.core.ObjectMapper
```

This is a breaking change, the lib will **NOT** be compatible with application servers that provide Jackson 1.x.
